### PR TITLE
refactor: rename file server, remove literal string using Backtick & remove unused file import

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const API_URL = 'https://api.lanyard.rest'

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,12 +1,13 @@
 import { HTTPDataSource } from "apollo-datasource-http";
 import { LanyardAPIData } from "./interfaces";
 import { Pool } from "undici";
+import { API_URL } from "./constants";
 
-const pool = new Pool("https://api.lanyard.rest");
+const pool = new Pool(API_URL);
 
 export default class LanyardAPI extends HTTPDataSource {
   constructor() {
-    super("https://api.lanyard.rest", {
+    super(API_URL, {
       pool,
       clientOptions: {
         bodyTimeout: 5000,
@@ -16,6 +17,6 @@ export default class LanyardAPI extends HTTPDataSource {
   }
 
   async getUser(user: string): Promise<LanyardAPIData> {
-    return (await this.get("/v1/users/" + user)) as unknown as LanyardAPIData;
+    return (await this.get(`/v1/users/${user}`)) as unknown as LanyardAPIData;
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,3 @@
-import LanyardAPI from "./DataSource";
-
 export interface LanyardAPIData {
   success: boolean;
   data: Data;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import server from "./Server";
+import server from "./server";
 
 server
   .listen(8080)

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,4 +1,3 @@
-import LanyardAPI from "../DataSource";
 import { LanyardAPIData } from "../interfaces";
 
 const Query = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { ApolloServer } from "apollo-server";
-import LanyardAPI from "./DataSource";
+import LanyardAPI from "./data-source";
 import resolvers from "./resolvers";
 import typeDefs from "./schema";
 


### PR DESCRIPTION
Hi, I added some changes to the main section, and DataSource

This is a list of some of the files I changed: 

- Rename DataSource to data-source
- reimport "./Server" to "./server"
- remove literang string and change to using backtick
- remove unused file import in some files